### PR TITLE
Handle errors caused by db hosts being unresponsive

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dbhijacker (0.11.0)
+    dbhijacker (0.12.1)
       rails (>= 2.3.14, < 4.0)
       redis (~> 3.0.7)
 

--- a/dbhijacker.gemspec
+++ b/dbhijacker.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.name = %q{dbhijacker}
   s.homepage = "https://github.com/crystalcommerce/hijacker"
-  s.version = "0.11.0"
+  s.version = "0.12.1"
 
   s.license = "MIT"
 

--- a/lib/hijacker/mysql_errors.rb
+++ b/lib/hijacker/mysql_errors.rb
@@ -1,0 +1,36 @@
+module Hijacker
+
+  MYSQL_UNRESPONSIVE_HOST = :unresponsive_host
+  MYSQL_UNKNOWN_HOST = :unknown_host
+  MYSQL_ACCESS_DENIED = :access_denied
+  MYSQL_GENERIC = :generic
+
+  module MysqlErrors
+    # Different kinds of Mysql2::Error
+    #
+    # Mysql2::Error: Can't connect to MySQL server on '169.44.133.61' (111)
+    # Mysql2::Error: Unknown MySQL server host 'asdf' (0)
+    # Mysql2::Error: Access denied for user 'xcrystal'@'169.44.133.34' (using password: YES)
+    # Mysql2::Error: Access denied for user 'crystal'@'169.44.133.34' (using password: YES)
+    #
+    RE_UNRESPONSIVE_HOST = /Can't connect to MySQL server on '([^']+)'/
+    RE_UNKNOWN_HOST = /Unknown MySQL server host '([^']+)'/
+    RE_ACCESS_DENIED = /Access denied for user '([^']+)/
+
+    def mysql_error(e)
+      if e.message.match(Hijacker::MysqlErrors::RE_UNRESPONSIVE_HOST)
+        MYSQL_UNRESPONSIVE_HOST
+      elsif e.message.match(Hijacker::MysqlErrors::RE_UNKNOWN_HOST)
+        MYSQL_UNKNOWN_HOST
+      elsif e.message.match(Hijacker::MysqlErrors::RE_ACCESS_DENIED)
+        MYSQL_ACCESS_DENIED
+      else
+        MYSQL_GENERIC
+      end
+    end
+
+    def mysql_error_is?(e, value)
+      (mysql_error(e) == value)
+    end
+  end
+end

--- a/lib/hijacker/redis_keys.rb
+++ b/lib/hijacker/redis_keys.rb
@@ -139,5 +139,35 @@ module Hijacker
         {}
       end
     end
+
+    def dbhost_available?(host, options={})
+      available = (host and (redis_unresponsive_dbhost_count(host) < unresponsive_dbhost_count_threshold))
+
+      if !available and options.has_key?(:host_id)
+        redis_add_unresponsive_dbhost_id(options[:host_id])
+      end
+
+      available
+    end
+
+    def increment_unresponsive_dbhost(host)
+      if host
+        redis_increment_unresponsive_dbhost(host)
+      end
+    end
+
+    def reset_unresponsive_dbhost(host)
+      if host
+        redis_reset_unresponsive_dbhost(host[:hostname]) if host.has_key?(:hostname)
+        redis_remove_unresponsive_dbhost_id(host[:id]) if host.has_key?(:id)
+      end
+    end
+      
+    # Translate from ip address to host name.  Simply return the ip address if
+    # there is no matching translation.
+    def translate_host_ip(host_ip_address)
+      redis_translation_table.fetch(host_ip_address, host_ip_address)
+    end
+    
   end
 end

--- a/lib/hijacker/unresponsive_host_error.rb
+++ b/lib/hijacker/unresponsive_host_error.rb
@@ -1,12 +1,13 @@
 module Hijacker
   class UnresponsiveHostError < StandardError
-    attr_reader :config, :host, :database_name, :custom_message
+    attr_reader :config, :host, :database_name, :original_error, :custom_message
 
-    def initialize(config={}, custom_message = nil)
-      @config = config
-      @host = config.fetch(:host, nil)
-      @database_name = config.fetch(:database, nil)
-      @custom_message = custom_message
+    def initialize(config={}, options={}, custom_message = nil)
+      @config          = config
+      @host            = config.fetch(:host, nil)
+      @database_name   = config.fetch(:database, nil)
+      @custom_message  = custom_message
+      @original_error  = config.fetch(:original_error, nil)
     end
 
     def message


### PR DESCRIPTION
Handle errors caused by db hosts being unresponsive so that when using connect_each, if an error is raised because a db host timed out on making the initial connection for a client database, increment the count and move on to the next client.

For more details on what these changes for hijacker are all about, see https://github.com/crystalcommerce/hijacker/pull/3