### PR TITLE
Refactors hijacker task for populating db host translation table

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,33 +19,4 @@ task :release => :gem do
   sh "gem push pkg/#{spec.name}-#{spec.version}.gem"
 end
 
-# Create a lookup hash for database host ipaddresses, translating to the more
-# human readable name (e.g., 'ds1204')
-require 'csv'
-require_relative './lib/hijacker/redis_keys'
-require 'redis'
-require_relative './config/initializers/redis'
-
-namespace :hijacker do
-  desc "Update Redis db ip address to hostname translation table using ./example/host_translations.csv"
-  task :setup_translation_table do |t, args|
-    extend Hijacker::RedisKeys
-
-    default_filepath = "./example/host_translations.csv"
-    custom_filepath = (args and args.extras and args.extras.length > 0 and File.exists?(args.extras[0]) and args.extras[0])
-    filepath = (custom_filepath or default_filepath)
-
-    if File.exists?(filepath)
-      # Make sure that file exists and can be parsed before deleting
-      # translation hash from Redis
-      data = CSV.parse(IO.read(filepath), { headers: true, converters: :numeric, header_converters: :symbol })
-
-      $hijacker_redis.del(redis_keys(:host_translations))
-      data.each do |row|
-        next unless row[:ipaddr] and row[:ipaddr].length > 0
-        $hijacker_redis.hset(redis_keys(:host_translations), row[:ipaddr], row[:hostname])
-      end
-    end
-  end
-end
-
+import "./tasks/hijacker.rake"

--- a/dbhijacker.gemspec
+++ b/dbhijacker.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.description = %q{Allows a single Rails appliation to access many different databases}
   s.email = %q{developers@crystalcommerce.com}
 
-  s.add_dependency("rails", ">= 2.3.14")
-  s.add_runtime_dependency("redis", "= 3.3.3")
+  s.add_dependency("rails", ">= 2.3.14", "< 4.0")
+  s.add_runtime_dependency("redis", "~> 3.0.7")
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "guard"

--- a/dbhijacker.gemspec
+++ b/dbhijacker.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.name = %q{dbhijacker}
   s.homepage = "https://github.com/crystalcommerce/hijacker"
-  s.version = "0.12.2"
+  s.version = "0.12.4"
 
   s.license = "MIT"
 
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.description = %q{Allows a single Rails appliation to access many different databases}
   s.email = %q{developers@crystalcommerce.com}
 
-  s.add_dependency("rails", ">= 2.3.14", "< 4.0")
-  s.add_runtime_dependency("redis", "~> 3.0.7")
+  s.add_dependency("rails", ">= 2.3.14")
+  s.add_runtime_dependency("redis", "= 3.3.3")
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "guard"

--- a/tasks/hijacker.rake
+++ b/tasks/hijacker.rake
@@ -1,0 +1,31 @@
+namespace :hijacker do
+
+  # Create a lookup hash for database host ipaddresses, translating to the more
+  # human readable name (e.g., 'ds1204')
+  require 'csv'
+  require_relative '../lib/hijacker/redis_keys'
+  require 'redis'
+  require_relative '../config/initializers/redis'
+  
+  desc "Update Redis db ip address to hostname translation table using ./example/host_translations.csv"
+  task :setup_translation_table do |t, args|
+    extend Hijacker::RedisKeys
+
+    default_filepath = "#{File.expand_path(File.dirname(__FILE__))}/../example/host_translations.csv"
+    custom_filepath = (args and args.extras and args.extras.length > 0 and File.exists?(args.extras[0]) and args.extras[0])
+    filepath = (custom_filepath or default_filepath)
+
+    if File.exists?(filepath)
+      # Make sure that file exists and can be parsed before deleting
+      # translation hash from Redis
+      data = CSV.parse(IO.read(filepath), { headers: true, converters: :numeric, header_converters: :symbol })
+
+      $hijacker_redis.del(redis_keys(:host_translations))
+      data.each do |row|
+        next unless row[:ipaddr] and row[:ipaddr].length > 0
+        $hijacker_redis.hset(redis_keys(:host_translations), row[:ipaddr], row[:hostname])
+      end
+    end
+  end
+end
+

--- a/tasks/hijacker_tasks.rake
+++ b/tasks/hijacker_tasks.rake
@@ -1,4 +1,0 @@
-# desc "Explaining what the task does"
-# task :hijacker do
-#   # Task goes here
-# end


### PR DESCRIPTION
Now other applications that call that rake task outside the hijacker gem can use the rake task successfully (e.g., db host translation table in Redis).
