### PR TITLE
Fixed issue of different schema of multi tenant architecture

### DIFF
--- a/lib/hijacker.rb
+++ b/lib/hijacker.rb
@@ -81,6 +81,8 @@ module Hijacker
 
       #reenable_query_caching
 
+      reset_column_info_for_active_record
+
       run_after_hijack_callback
 
       #logger.debug "#{database.host} was responsive; resetting counter"
@@ -292,6 +294,15 @@ private
 
   def self.run_after_hijack_callback
     config[:after_hijack].call if config[:after_hijack]
+  end
+
+  # Reset column information to ensure models are up-to-date with the new schema.
+  # This ensures that any changes to the database schema are immediately
+  # in a multi-tenant architecture where different tenants might have
+  def self.reset_column_info_for_active_record
+    ::ActiveRecord::Base.descendants.each do |klass|
+      klass.reset_column_information
+    end
   end
 end
 


### PR DESCRIPTION
- Reset column information to ensure models are up-to-date with the new schema.
- This ensures that any changes to the database schema are immediately
- In a multi-tenant architecture where different tenants might have

Example :- 

```
MySQL [**worldofwarcraft**]> DESCRIBE customer_fields;
+-------+--------------+------+-----+---------+----------------+
| Field | Type         | Null | Key | Default | Extra          |
+-------+--------------+------+-----+---------+----------------+
| id    | int          | NO   | PRI | NULL    | auto_increment |
| label | varchar(255) | YES  |     | NULL    |                |
+-------+--------------+------+-----+---------+----------------+
2 rows in set (0.01 sec)
```

```
MySQL [**bluedefault**]> DESCRIBE customer_fields;
+----------+--------------+------+-----+---------+----------------+
| Field    | Type         | Null | Key | Default | Extra          |
+----------+--------------+------+-----+---------+----------------+
| id       | int          | NO   | PRI | NULL    | auto_increment |
| label    | varchar(255) | YES  |     | NULL    |                |
| required | tinyint(1)   | YES  |     | 0       |                |
+----------+--------------+------+-----+---------+----------------+
3 rows in set (0.00 sec)
```

As you can see the table columns are different on both databases.Now when I switch the database from **bluedefault** to **worldofwarcraft** database then we're also getting the `required` column on **worldofwarcraft** database because schema is not updated on run time of the application.

So `reset_column_information` used to ensure models are up-to-date with the new schema after switching the databases.